### PR TITLE
Updated type hints of `User`

### DIFF
--- a/snowfin/client.py
+++ b/snowfin/client.py
@@ -91,7 +91,7 @@ class Client:
             headers=kwargs.get('headers', None),
         )
 
-        self.user: User | None = None
+        self.user: Optional[User] = None
 
         self.modules = {}
 

--- a/snowfin/client.py
+++ b/snowfin/client.py
@@ -91,7 +91,7 @@ class Client:
             headers=kwargs.get('headers', None),
         )
 
-        self.user: User = None
+        self.user: User | None = None
 
         self.modules = {}
 

--- a/snowfin/models.py
+++ b/snowfin/models.py
@@ -27,7 +27,7 @@ class User:
     id: int
     username: str
     discriminator: str
-    avatar: str
+    avatar: str | None
     bot: Optional[bool]
     mfa_enabled: Optional[bool]
     banner: Optional[str]

--- a/snowfin/models.py
+++ b/snowfin/models.py
@@ -27,7 +27,7 @@ class User:
     id: int
     username: str
     discriminator: str
-    avatar: str | None
+    avatar: Optional[str]
     bot: Optional[bool]
     mfa_enabled: Optional[bool]
     banner: Optional[str]


### PR DESCRIPTION
While fetching the user, the avatar can sometimes be None. This would cause the raise of `dacite.exceptions.WrongTypeError`. 
Also changed the type hint of the user attribute of `Client` to `Optional[User]` as it was declared as None.