### PR TITLE
fix: added `snowfin.Client.command` and set the logging level

### DIFF
--- a/snowfin/client.py
+++ b/snowfin/client.py
@@ -114,6 +114,9 @@ class Client:
         # gather callbacks
         self._gather_callbacks()
 
+        # set logging level
+        logger.setLevel(logging_level)
+
         # create some middleware for start and stop events
         @self.app.listener("after_server_start")
         async def on_start(app, loop):
@@ -670,3 +673,8 @@ class Client:
         data = await self.http.fetch_user(user_id)
         if data is not None:
             return from_dict(User, data, config=cast_config)
+
+    def command(self, command: SlashCommand) -> SlashCommand:
+        """Adds a command to the bot"""
+        self.commands.append(command)
+        return command


### PR DESCRIPTION
The issue with some commands is the command was not getting added to the bot. To fix this I added `snowfin.Client.command`.
Now a command may look like:
```py
@bot.command
@snowfin.slash_command(name="hello")
async def hello(context: Interaction):
    return MessageResponse('Ok, *Now* I want to respond ;)')
```