### PR TITLE
Show full exception information

### DIFF
--- a/snowfin/client.py
+++ b/snowfin/client.py
@@ -225,7 +225,7 @@ class Client:
                 if after:
                     await self._handle_followup_response(request, after)
             except Exception as e:
-                logger.error(e.__repr__())
+                logger.exception(e)
 
         asyncio.create_task(wrapper())
 


### PR DESCRIPTION
Currently, errors are left in a cryptic state as the full traceback information is not shown. This changes that.